### PR TITLE
Added support for OR (pipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ Examples
     "i2"
     => (re-rand #"b(an)+a")
     ["bananananananana" "an"]
+    => (re-rand #"(North|South|Lake)(town|ville|land)")
+    ["Lakeville" "Lake" "ville"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject re-rand "0.1.0"
   :description "Generates random strings from regular expressions"
-  :dependencies [[org.clojure/clojure "1.1.0"]]
+  :dependencies [[org.clojure/clojure "1.2.0"]]
   :dev-dependencies [[lein-clojars "0.5.0"]])

--- a/src/re_rand/parser/tools.clj
+++ b/src/re_rand/parser/tools.clj
@@ -42,7 +42,7 @@
   (fn [src]
     (reduce
       (fn [[xs s] rule]
-        (if (seq s)
+        (if-not (nil? s)
           (if-let [[x s] (rule s)]
             [(conj xs x) s])))
       [[] src]


### PR DESCRIPTION
Added support for alternatives in the expression, such as;

```
user=> (re-rand #"(555|1-800)-(\d{3} \d{3}|[A-Z]+)|unlisted")
["555-654 606" "555" "654 606"]
user=> (re-rand #"(555|1-800)-(\d{3} \d{3}|[A-Z]+)|unlisted")
"unlisted"
user=> (re-rand #"(555|1-800)-(\d{3} \d{3}|[A-Z]+)|unlisted")
["1-800-054 837" "1-800" "054 837"]
user=> (re-rand #"(555|1-800)-(\d{3} \d{3}|[A-Z]+)|unlisted")
["555-DJE" "555" "DJE"]
user=> (re-rand #"(555|1-800)-(\d{3} \d{3}|[A-Z]+)|unlisted")
["1-800-ARDB" "1-800" "ARDB"]
```

Modified `series` to allow it to continue matching against an empty string (or rather, until some rule returns nil), as the `pattern` rule now ends with `many` that may successfully match zero times against the empty string (i.e. when alternatives are not used in the pattern).

Closes #2.
